### PR TITLE
use pivot for position (support for models)

### DIFF
--- a/library/sense/source.lua
+++ b/library/sense/source.lua
@@ -522,7 +522,7 @@ function InstanceObject:Render()
 			text.Text = options.text
 				:gsub("{name}", instance.Name)
 				:gsub("{distance}", round(depth))
-				:gsub("{position}", tostring(instance.Position));
+				:gsub("{position}", tostring(world));
 		end
 	else
 		text.Visible = false


### PR DESCRIPTION
**Changes**
A minor change. 
- It makes the position for the text use the pivot's position that was used earlier. Without this, models are not supported.

**Remarks**
- The documentation is outdated in terms of the Instance ESP. The `AddInstance` method returns a table instead of the object itself. Therefore, `object.enabled = true` does not work, but `object[1].enabled = true` would work. I did not fix this, just in case this was intended or that would cause further issues.
- While looking at the code, I noticed that you could clean it up significantly with the use of [guard clauses](https://refactoring.com/catalog/replaceNestedConditionalWithGuardClauses.html)
- A personal preference, but semi-colons do not belong in Lua